### PR TITLE
Update edge and vertex ID to work with AWS Neptune and Gremlin defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .gopath~
 .DS_Store
 .vscode
-
+.idea
 # Directories
 vendor
 bin

--- a/model/edge.go
+++ b/model/edge.go
@@ -44,7 +44,12 @@ func (e *Edge) PropertyValue(key string) interface{} {
 
 // ID will retrieve the Edge ID for you.
 func (e *Edge) ID() interface{} {
-	return e.Value.ID
+	idMap, ok := e.Value.ID.(map[string]interface{})
+	if !ok {
+		return e.Value.ID
+	}
+
+	return idMap["@value"]
 }
 
 // Label will retrieve the Edge Label for you.

--- a/model/vertex.go
+++ b/model/vertex.go
@@ -77,7 +77,12 @@ func (v *Vertex) PropertyMap() PropertyMap {
 // ID will retrieve the Vertex ID for you
 // without having to traverse all the way through the structures.
 func (v *Vertex) ID() interface{} {
-	return v.Value.ID
+	idMap, ok := v.Value.ID.(map[string]interface{})
+	if !ok {
+		return v.Value.ID
+	}
+
+	return idMap["@value"]
 }
 
 // Label retrieves the label of the vertex


### PR DESCRIPTION
Currently users who are using grammes have to switch between v1.1.2 for local and v1.2.0 for AWS Neptune. This will allow users to work with both of them.